### PR TITLE
feat!: switch to named export

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ repo and examine the changes made.
 
 -->
 
-```js
-const toMultiaddr = require('uri-to-multiaddr')
+```typescript
+import { uriToMultiaddr } from '@multiformats/uri-to-multiaddr'
 
-console.log(toMultiaddr('https://protocol.ai'))
+console.log(uriToMultiaddr('https://protocol.ai'))
 // -> /dns4/protocol.ai/tcp/443/https
 ```
 
@@ -40,10 +40,10 @@ This library assumes `/dns4` when it finds a domain name in the input string.
 It makes no attempt query DNS. To override the default assumption, you can pass
 in an options object as the second parameter to override it:
 
-```js
-const toMultiaddr = require('uri-to-multiaddr')
+```typescript
+import { uriToMultiaddr } from '@multiformats/uri-to-multiaddr'
 
-console.log(toMultiaddr('https://protocol.ai'), { defaultDnsType: 'dns6' })
+console.log(uriToMultiaddr('https://protocol.ai'), { defaultDnsType: 'dns6' })
 // -> /dns6/protocol.ai/tcp/443/https
 ```
 
@@ -56,7 +56,7 @@ See [test.js](./test.js) for the currently supported conversions.
 
 ## Related
 
-- [multiaddr-to-uri](https://github.com/multiformats/js-multiaddr-to-uri) - convert it back again
+- [@multiformats/multiaddr-to-uri](https://github.com/multiformats/js-multiaddr-to-uri) - convert it back again
 
 # Install
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,10 @@
 /**
  * @packageDocumentation
  *
- * ```js
- * const toMultiaddr = require('uri-to-multiaddr')
+ * ```typescript
+ * import { uriToMultiaddr } from '@multiformats/uri-to-multiaddr'
  *
- * console.log(toMultiaddr('https://protocol.ai'))
+ * console.log(uriToMultiaddr('https://protocol.ai'))
  * // -> /dns4/protocol.ai/tcp/443/https
  * ```
  *
@@ -18,10 +18,10 @@
  * It makes no attempt query DNS. To override the default assumption, you can pass
  * in an options object as the second parameter to override it:
  *
- * ```js
- * const toMultiaddr = require('uri-to-multiaddr')
+ * ```typescript
+ * import { uriToMultiaddr } from '@multiformats/uri-to-multiaddr'
  *
- * console.log(toMultiaddr('https://protocol.ai'), { defaultDnsType: 'dns6' })
+ * console.log(uriToMultiaddr('https://protocol.ai'), { defaultDnsType: 'dns6' })
  * // -> /dns6/protocol.ai/tcp/443/https
  * ```
  *
@@ -34,7 +34,7 @@
  *
  * ## Related
  *
- * - [multiaddr-to-uri](https://github.com/multiformats/js-multiaddr-to-uri) - convert it back again
+ * - [@multiformats/multiaddr-to-uri](https://github.com/multiformats/js-multiaddr-to-uri) - convert it back again
  */
 
 import { multiaddr } from '@multiformats/multiaddr'
@@ -66,7 +66,7 @@ export interface MultiaddrFromUriOpts {
  * udp://foobar.com:8080 => /dns4/foobar.com/udp/8080
  */
 
-export default function multiaddrFromUri (uriStr: string, opts?: MultiaddrFromUriOpts): Multiaddr {
+export function uriToMultiaddr (uriStr: string, opts?: MultiaddrFromUriOpts): Multiaddr {
   opts = opts ?? {}
   const defaultDnsType = opts.defaultDnsType ?? 'dns4'
   const { scheme, hostname, port } = parseUri(uriStr)

--- a/test/test.spec.ts
+++ b/test/test.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from 'aegir/chai'
-import toMultiaddr from '../src/index.js'
+import { uriToMultiaddr } from '../src/index.js'
 import type { MultiaddrFromUriOpts } from '../src/index.js'
 
 describe('uri-to-multiaddr', () => {
@@ -33,7 +33,7 @@ describe('uri-to-multiaddr', () => {
     data.forEach(d => {
       const input = d[1]
       const expected = d[0]
-      const output = toMultiaddr(input).toString()
+      const output = uriToMultiaddr(input).toString()
       expect(output).to.equal(expected, `Converts ${input} to ${expected}`)
     })
   })
@@ -46,20 +46,20 @@ describe('uri-to-multiaddr', () => {
     ]
 
     data.forEach(d => {
-      expect(toMultiaddr(d[1], d[2]).toString()).to.equal(d[0], `Converts ${d[1]} to ${d[0]} with opts ${JSON.stringify(d[2])}`)
+      expect(uriToMultiaddr(d[1], d[2]).toString()).to.equal(d[0], `Converts ${d[1]} to ${d[0]} with opts ${JSON.stringify(d[2])}`)
     })
   })
 
   it('should throw for on invalid url', () => {
     expect(() => {
-      toMultiaddr('whoosh.fast')
+      uriToMultiaddr('whoosh.fast')
     }).to.throw(/URL/)
   })
 
   it('should throw for unknown protocol', () => {
     expect(() => {
       // NOTE: `data` is a valid uri protocol but isn't a valid multiaddr protocol yet
-      toMultiaddr('data:image/svg+xml;base64,test')
+      uriToMultiaddr('data:image/svg+xml;base64,test')
     }).to.throw('no protocol with name: data')
   })
 })


### PR DESCRIPTION
To better mirror `@multiformats/multiaddr-to-uri`, switch to a named export.

BREAKING CHANGE: the default export has been replaced with a named export of `uriToMultiaddr`