### PR TITLE
fix: prefer /dns to allow resolving A or AAAA records

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -51,24 +51,31 @@ const portFor: Record<string, string> = {
 const BROWSER_SCHEMES = ['http', 'https', 'ws', 'wss']
 
 export interface MultiaddrFromUriOpts {
-  defaultDnsType?: string
+  /**
+   * If a URI contains a domain name, by default the `/dns/` tuple will be used
+   * to define it. If you wish to use `/dnsaddr` or something more specific like
+   * `/dns4` or `/dns6`, pass it as an option here.
+   *
+   * @default 'dns'
+   */
+  defaultDnsType?: 'dns' | 'dns4' | 'dns6' | 'dnsaddr'
 }
 
 /**
  * Convert a URI to a multiaddr
  *
- * http://foobar.com => /dns4/foobar.com/tcp/80/http
- * https://foobar.com => /dns4/foobar.com/tcp/443/https
- * https://foobar.com:5001 => /dns4/foobar.com/tcp/5001/https
+ * http://foobar.com => /dns/foobar.com/tcp/80/http
+ * https://foobar.com => /dns/foobar.com/tcp/443/https
+ * https://foobar.com:5001 => /dns/foobar.com/tcp/5001/https
  * https://127.0.0.1:8080 => /ip4/127.0.0.1/tcp/8080/https
  * http://[::1]:8080 => /ip6/::1/tcp/8080/http
- * tcp://foobar.com:8080 => /dns4/foobar.com/tcp/8080
- * udp://foobar.com:8080 => /dns4/foobar.com/udp/8080
+ * tcp://foobar.com:8080 => /dns/foobar.com/tcp/8080
+ * udp://foobar.com:8080 => /dns/foobar.com/udp/8080
  */
 
 export function uriToMultiaddr (uriStr: string, opts?: MultiaddrFromUriOpts): Multiaddr {
   opts = opts ?? {}
-  const defaultDnsType = opts.defaultDnsType ?? 'dns4'
+  const defaultDnsType = opts.defaultDnsType ?? 'dns'
   const { scheme, hostname, port, path } = parseUri(uriStr)
   const parts = [
     tupleForHostname(hostname, defaultDnsType),

--- a/test/test.spec.ts
+++ b/test/test.spec.ts
@@ -4,7 +4,7 @@ import type { MultiaddrFromUriOpts } from '../src/index.js'
 
 describe('uri-to-multiaddr', () => {
   it('should convert URIs to multiaddrs', () => {
-    const data = [
+    const data: Array<[string, string, MultiaddrFromUriOpts?]> = [
       ['/ip4/127.0.0.1/tcp/80/http', 'http://127.0.0.1'],
       ['/ip6/fc00::/tcp/80/http', 'http://[fc00::]'],
       ['/ip4/0.0.7.6/tcp/1234', 'tcp://0.0.7.6:1234'],
@@ -13,28 +13,128 @@ describe('uri-to-multiaddr', () => {
       ['/ip6/::/tcp/0', 'tcp://[::]:0'],
       ['/ip4/0.0.7.6/udp/1234', 'udp://0.0.7.6:1234'],
       ['/ip6/::/udp/0', 'udp://[::]:0'],
-      ['/dns4/protocol.ai/tcp/80', 'tcp://protocol.ai:80'],
-      ['/dns4/protocol.ai/tcp/80/http', 'http://protocol.ai:80'],
-      ['/dns4/protocol.ai/tcp/80/https', 'https://protocol.ai:80'],
-      ['/dns4/ipfs.io/tcp/80/ws', 'ws://ipfs.io'],
-      ['/dns4/ipfs.io/tcp/443/wss', 'wss://ipfs.io'],
-      ['/dns4/ipfs.io/tcp/80/http', 'http://ipfs.io'],
-      ['/dns4/ipfs.io/tcp/443/https', 'https://ipfs.io'],
-      ['/dns4/ipfs.io/tcp/443/https', 'https://ipfs.io:443'],
-      ['/dns4/ipfs.io/tcp/443', 'tcp://ipfs.io:443'],
-      ['/dns4/ipfs.io/tcp/80', 'tcp://ipfs.io:80'],
+      ['/dns/protocol.ai/tcp/80', 'tcp://protocol.ai:80'],
+      ['/dns4/protocol.ai/tcp/80', 'tcp://protocol.ai:80', {
+        defaultDnsType: 'dns4'
+      }],
+      ['/dns6/protocol.ai/tcp/80', 'tcp://protocol.ai:80', {
+        defaultDnsType: 'dns6'
+      }],
+      ['/dnsaddr/protocol.ai/tcp/80', 'tcp://protocol.ai:80', {
+        defaultDnsType: 'dnsaddr'
+      }],
+      ['/dns/protocol.ai/tcp/80/http', 'http://protocol.ai:80'],
+      ['/dns4/protocol.ai/tcp/80/http', 'http://protocol.ai:80', {
+        defaultDnsType: 'dns4'
+      }],
+      ['/dns6/protocol.ai/tcp/80/http', 'http://protocol.ai:80', {
+        defaultDnsType: 'dns6'
+      }],
+      ['/dnsaddr/protocol.ai/tcp/80/http', 'http://protocol.ai:80', {
+        defaultDnsType: 'dnsaddr'
+      }],
+      ['/dns/protocol.ai/tcp/80/https', 'https://protocol.ai:80'],
+      ['/dns4/protocol.ai/tcp/80/https', 'https://protocol.ai:80', {
+        defaultDnsType: 'dns4'
+      }],
+      ['/dns6/protocol.ai/tcp/80/https', 'https://protocol.ai:80', {
+        defaultDnsType: 'dns6'
+      }],
+      ['/dnsaddr/protocol.ai/tcp/80/https', 'https://protocol.ai:80', {
+        defaultDnsType: 'dnsaddr'
+      }],
+      ['/dns/ipfs.io/tcp/80/ws', 'ws://ipfs.io'],
+      ['/dns4/ipfs.io/tcp/80/ws', 'ws://ipfs.io', {
+        defaultDnsType: 'dns4'
+      }],
+      ['/dns6/ipfs.io/tcp/80/ws', 'ws://ipfs.io', {
+        defaultDnsType: 'dns6'
+      }],
+      ['/dnsaddr/ipfs.io/tcp/80/ws', 'ws://ipfs.io', {
+        defaultDnsType: 'dnsaddr'
+      }],
+      ['/dns/ipfs.io/tcp/443/wss', 'wss://ipfs.io'],
+      ['/dns4/ipfs.io/tcp/443/wss', 'wss://ipfs.io', {
+        defaultDnsType: 'dns4'
+      }],
+      ['/dns6/ipfs.io/tcp/443/wss', 'wss://ipfs.io', {
+        defaultDnsType: 'dns6'
+      }],
+      ['/dnsaddr/ipfs.io/tcp/443/wss', 'wss://ipfs.io', {
+        defaultDnsType: 'dnsaddr'
+      }],
+      ['/dns/ipfs.io/tcp/80/http', 'http://ipfs.io'],
+      ['/dns4/ipfs.io/tcp/80/http', 'http://ipfs.io', {
+        defaultDnsType: 'dns4'
+      }],
+      ['/dns6/ipfs.io/tcp/80/http', 'http://ipfs.io', {
+        defaultDnsType: 'dns6'
+      }],
+      ['/dnsaddr/ipfs.io/tcp/80/http', 'http://ipfs.io', {
+        defaultDnsType: 'dnsaddr'
+      }],
+      ['/dns/ipfs.io/tcp/443/https', 'https://ipfs.io'],
+      ['/dns4/ipfs.io/tcp/443/https', 'https://ipfs.io', {
+        defaultDnsType: 'dns4'
+      }],
+      ['/dns6/ipfs.io/tcp/443/https', 'https://ipfs.io', {
+        defaultDnsType: 'dns6'
+      }],
+      ['/dnsaddr/ipfs.io/tcp/443/https', 'https://ipfs.io', {
+        defaultDnsType: 'dnsaddr'
+      }],
+      ['/dns/ipfs.io/tcp/443/https', 'https://ipfs.io:443'],
+      ['/dns4/ipfs.io/tcp/443/https', 'https://ipfs.io:443', {
+        defaultDnsType: 'dns4'
+      }],
+      ['/dns6/ipfs.io/tcp/443/https', 'https://ipfs.io:443', {
+        defaultDnsType: 'dns6'
+      }],
+      ['/dnsaddr/ipfs.io/tcp/443/https', 'https://ipfs.io:443', {
+        defaultDnsType: 'dnsaddr'
+      }],
+      ['/dns/ipfs.io/tcp/443', 'tcp://ipfs.io:443'],
+      ['/dns4/ipfs.io/tcp/443', 'tcp://ipfs.io:443', {
+        defaultDnsType: 'dns4'
+      }],
+      ['/dns6/ipfs.io/tcp/443', 'tcp://ipfs.io:443', {
+        defaultDnsType: 'dns6'
+      }],
+      ['/dnsaddr/ipfs.io/tcp/443', 'tcp://ipfs.io:443', {
+        defaultDnsType: 'dnsaddr'
+      }],
+      ['/dns/ipfs.io/tcp/80', 'tcp://ipfs.io:80'],
+      ['/dns4/ipfs.io/tcp/80', 'tcp://ipfs.io:80', {
+        defaultDnsType: 'dns4'
+      }],
+      ['/dns6/ipfs.io/tcp/80', 'tcp://ipfs.io:80', {
+        defaultDnsType: 'dns6'
+      }],
+      ['/dnsaddr/ipfs.io/tcp/80', 'tcp://ipfs.io:80', {
+        defaultDnsType: 'dnsaddr'
+      }],
       ['/ip4/1.2.3.4/tcp/3456/ws', 'ws://1.2.3.4:3456'],
       ['/ip4/1.2.3.4/tcp/3456/wss', 'wss://1.2.3.4:3456'],
       ['/ip6/::/tcp/0/ws', 'ws://[::]:0'],
       ['/ip4/1.2.3.4/tcp/3456/wss', 'wss://1.2.3.4:3456'],
       ['/ip6/::/tcp/0/wss', 'wss://[::]:0'],
-      ['/dns4/example.com/tcp/443/wss/http-path/foo', 'wss://example.com:443/foo']
+      ['/dns/example.com/tcp/443/wss/http-path/foo', 'wss://example.com:443/foo'],
+      ['/dns4/example.com/tcp/443/wss/http-path/foo', 'wss://example.com:443/foo', {
+        defaultDnsType: 'dns4'
+      }],
+      ['/dns6/example.com/tcp/443/wss/http-path/foo', 'wss://example.com:443/foo', {
+        defaultDnsType: 'dns6'
+      }],
+      ['/dnsaddr/example.com/tcp/443/wss/http-path/foo', 'wss://example.com:443/foo', {
+        defaultDnsType: 'dnsaddr'
+      }]
     ]
 
     data.forEach(d => {
       const input = d[1]
       const expected = d[0]
-      const output = uriToMultiaddr(input).toString()
+      const opts = d[2]
+      const output = uriToMultiaddr(input, opts).toString()
       expect(output).to.equal(expected, `Converts ${input} to ${expected}`)
     })
   })


### PR DESCRIPTION
Default to `/dns` and allow overriding to use `/dns4`, `/dns6`, etc.

Fixes #8