### PR TITLE
fix: prefer /tls/http to /https and /tls/ws to /wss

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -181,6 +181,14 @@ function tupleForScheme (scheme: string): [string] | undefined {
     return undefined
   }
 
+  if (scheme === 'https') {
+    return ['/tls/http']
+  }
+
+  if (scheme === 'wss') {
+    return ['/tls/ws']
+  }
+
   return [scheme]
 }
 

--- a/test/test.spec.ts
+++ b/test/test.spec.ts
@@ -9,7 +9,7 @@ describe('uri-to-multiaddr', () => {
       ['/ip6/fc00::/tcp/80/http', 'http://[fc00::]'],
       ['/ip4/0.0.7.6/tcp/1234', 'tcp://0.0.7.6:1234'],
       ['/ip4/0.0.7.6/tcp/1234/http', 'http://0.0.7.6:1234'],
-      ['/ip4/0.0.7.6/tcp/1234/https', 'https://0.0.7.6:1234'],
+      ['/ip4/0.0.7.6/tcp/1234/tls/http', 'https://0.0.7.6:1234'],
       ['/ip6/::/tcp/0', 'tcp://[::]:0'],
       ['/ip4/0.0.7.6/udp/1234', 'udp://0.0.7.6:1234'],
       ['/ip6/::/udp/0', 'udp://[::]:0'],
@@ -33,14 +33,14 @@ describe('uri-to-multiaddr', () => {
       ['/dnsaddr/protocol.ai/tcp/80/http', 'http://protocol.ai:80', {
         defaultDnsType: 'dnsaddr'
       }],
-      ['/dns/protocol.ai/tcp/80/https', 'https://protocol.ai:80'],
-      ['/dns4/protocol.ai/tcp/80/https', 'https://protocol.ai:80', {
+      ['/dns/protocol.ai/tcp/80/tls/http', 'https://protocol.ai:80'],
+      ['/dns4/protocol.ai/tcp/80/tls/http', 'https://protocol.ai:80', {
         defaultDnsType: 'dns4'
       }],
-      ['/dns6/protocol.ai/tcp/80/https', 'https://protocol.ai:80', {
+      ['/dns6/protocol.ai/tcp/80/tls/http', 'https://protocol.ai:80', {
         defaultDnsType: 'dns6'
       }],
-      ['/dnsaddr/protocol.ai/tcp/80/https', 'https://protocol.ai:80', {
+      ['/dnsaddr/protocol.ai/tcp/80/tls/http', 'https://protocol.ai:80', {
         defaultDnsType: 'dnsaddr'
       }],
       ['/dns/ipfs.io/tcp/80/ws', 'ws://ipfs.io'],
@@ -53,14 +53,14 @@ describe('uri-to-multiaddr', () => {
       ['/dnsaddr/ipfs.io/tcp/80/ws', 'ws://ipfs.io', {
         defaultDnsType: 'dnsaddr'
       }],
-      ['/dns/ipfs.io/tcp/443/wss', 'wss://ipfs.io'],
-      ['/dns4/ipfs.io/tcp/443/wss', 'wss://ipfs.io', {
+      ['/dns/ipfs.io/tcp/443/tls/ws', 'wss://ipfs.io'],
+      ['/dns4/ipfs.io/tcp/443/tls/ws', 'wss://ipfs.io', {
         defaultDnsType: 'dns4'
       }],
-      ['/dns6/ipfs.io/tcp/443/wss', 'wss://ipfs.io', {
+      ['/dns6/ipfs.io/tcp/443/tls/ws', 'wss://ipfs.io', {
         defaultDnsType: 'dns6'
       }],
-      ['/dnsaddr/ipfs.io/tcp/443/wss', 'wss://ipfs.io', {
+      ['/dnsaddr/ipfs.io/tcp/443/tls/ws', 'wss://ipfs.io', {
         defaultDnsType: 'dnsaddr'
       }],
       ['/dns/ipfs.io/tcp/80/http', 'http://ipfs.io'],
@@ -73,24 +73,24 @@ describe('uri-to-multiaddr', () => {
       ['/dnsaddr/ipfs.io/tcp/80/http', 'http://ipfs.io', {
         defaultDnsType: 'dnsaddr'
       }],
-      ['/dns/ipfs.io/tcp/443/https', 'https://ipfs.io'],
-      ['/dns4/ipfs.io/tcp/443/https', 'https://ipfs.io', {
+      ['/dns/ipfs.io/tcp/443/tls/http', 'https://ipfs.io'],
+      ['/dns4/ipfs.io/tcp/443/tls/http', 'https://ipfs.io', {
         defaultDnsType: 'dns4'
       }],
-      ['/dns6/ipfs.io/tcp/443/https', 'https://ipfs.io', {
+      ['/dns6/ipfs.io/tcp/443/tls/http', 'https://ipfs.io', {
         defaultDnsType: 'dns6'
       }],
-      ['/dnsaddr/ipfs.io/tcp/443/https', 'https://ipfs.io', {
+      ['/dnsaddr/ipfs.io/tcp/443/tls/http', 'https://ipfs.io', {
         defaultDnsType: 'dnsaddr'
       }],
-      ['/dns/ipfs.io/tcp/443/https', 'https://ipfs.io:443'],
-      ['/dns4/ipfs.io/tcp/443/https', 'https://ipfs.io:443', {
+      ['/dns/ipfs.io/tcp/443/tls/http', 'https://ipfs.io:443'],
+      ['/dns4/ipfs.io/tcp/443/tls/http', 'https://ipfs.io:443', {
         defaultDnsType: 'dns4'
       }],
-      ['/dns6/ipfs.io/tcp/443/https', 'https://ipfs.io:443', {
+      ['/dns6/ipfs.io/tcp/443/tls/http', 'https://ipfs.io:443', {
         defaultDnsType: 'dns6'
       }],
-      ['/dnsaddr/ipfs.io/tcp/443/https', 'https://ipfs.io:443', {
+      ['/dnsaddr/ipfs.io/tcp/443/tls/http', 'https://ipfs.io:443', {
         defaultDnsType: 'dnsaddr'
       }],
       ['/dns/ipfs.io/tcp/443', 'tcp://ipfs.io:443'],
@@ -114,18 +114,18 @@ describe('uri-to-multiaddr', () => {
         defaultDnsType: 'dnsaddr'
       }],
       ['/ip4/1.2.3.4/tcp/3456/ws', 'ws://1.2.3.4:3456'],
-      ['/ip4/1.2.3.4/tcp/3456/wss', 'wss://1.2.3.4:3456'],
+      ['/ip4/1.2.3.4/tcp/3456/tls/ws', 'wss://1.2.3.4:3456'],
       ['/ip6/::/tcp/0/ws', 'ws://[::]:0'],
-      ['/ip4/1.2.3.4/tcp/3456/wss', 'wss://1.2.3.4:3456'],
-      ['/ip6/::/tcp/0/wss', 'wss://[::]:0'],
-      ['/dns/example.com/tcp/443/wss/http-path/foo', 'wss://example.com:443/foo'],
-      ['/dns4/example.com/tcp/443/wss/http-path/foo', 'wss://example.com:443/foo', {
+      ['/ip4/1.2.3.4/tcp/3456/tls/ws', 'wss://1.2.3.4:3456'],
+      ['/ip6/::/tcp/0/tls/ws', 'wss://[::]:0'],
+      ['/dns/example.com/tcp/443/tls/ws/http-path/foo', 'wss://example.com:443/foo'],
+      ['/dns4/example.com/tcp/443/tls/ws/http-path/foo', 'wss://example.com:443/foo', {
         defaultDnsType: 'dns4'
       }],
-      ['/dns6/example.com/tcp/443/wss/http-path/foo', 'wss://example.com:443/foo', {
+      ['/dns6/example.com/tcp/443/tls/ws/http-path/foo', 'wss://example.com:443/foo', {
         defaultDnsType: 'dns6'
       }],
-      ['/dnsaddr/example.com/tcp/443/wss/http-path/foo', 'wss://example.com:443/foo', {
+      ['/dnsaddr/example.com/tcp/443/tls/ws/http-path/foo', 'wss://example.com:443/foo', {
         defaultDnsType: 'dnsaddr'
       }]
     ]
@@ -143,7 +143,7 @@ describe('uri-to-multiaddr', () => {
     const data: Array<[string, string, MultiaddrFromUriOpts]> = [
       ['/dns4/protocol.ai/tcp/80', 'tcp://protocol.ai:80', { defaultDnsType: 'dns4' }],
       ['/dns6/protocol.ai/tcp/80/http', 'http://protocol.ai:80', { defaultDnsType: 'dns6' }],
-      ['/dnsaddr/protocol.ai/tcp/80/https', 'https://protocol.ai:80', { defaultDnsType: 'dnsaddr' }]
+      ['/dnsaddr/protocol.ai/tcp/80/tls/http', 'https://protocol.ai:80', { defaultDnsType: 'dnsaddr' }]
     ]
 
     data.forEach(d => {


### PR DESCRIPTION
The [HTTP spec](https://github.com/libp2p/specs/tree/master/http) settled on `/tls/http` over `/https` to allow including things like `/sni` in the multiaddr, so return `/tls/http` in favour of `/https` here.

Fixes #6